### PR TITLE
Add missing ProjectBoard components and fix frontend bugs

### DIFF
--- a/ppmtool-react-client/src/App.js
+++ b/ppmtool-react-client/src/App.js
@@ -9,6 +9,9 @@ import AddProject from "./components/Project/AddProject";
 import { Provider } from "react-redux";
 import store from "./store";
 import UpdateProject from "./components/Project/UpdateProject";
+import ProjectBoard from "./components/ProjectBoard/ProjectBoard";
+import AddProjectTask from "./components/ProjectBoard/ProjectTasks/AddProjectTask";
+import UpdateProjectTask from "./components/ProjectBoard/ProjectTasks/UpdateProjectTask";
 
 class App extends Component {
   render() {
@@ -20,6 +23,9 @@ class App extends Component {
             <Route exact path="/dashboard" component={Dashboard} />
             <Route exact path="/addProject" component={AddProject} />
             <Route exact path="/updateProject/:id" component={UpdateProject} />
+            <Route exact path="/projectBoard/:id" component={ProjectBoard} />
+            <Route exact path="/addProjectTask/:id" component={AddProjectTask} />
+            <Route exact path="/updateProjectTask/:backlog_id/:pt_id" component={UpdateProjectTask} />
           </div>
         </Router>
       </Provider>

--- a/ppmtool-react-client/src/actions/backlogActions.js
+++ b/ppmtool-react-client/src/actions/backlogActions.js
@@ -1,0 +1,76 @@
+import axios from "axios";
+import {
+  GET_ERRORS,
+  GET_BACKLOG,
+  GET_PROJECT_TASK,
+  DELETE_PROJECT_TASK
+} from "./types";
+
+export const addProjectTask = (backlog_id, project_task, history) => async dispatch => {
+  try {
+    const res = await axios.post(`/api/backlog/${backlog_id}`, project_task);
+    history.push(`/projectBoard/${backlog_id}`);
+    dispatch({
+      type: GET_ERRORS,
+      payload: {}
+    });
+  } catch (err) {
+    dispatch({
+      type: GET_ERRORS,
+      payload: err.response.data
+    });
+  }
+};
+
+export const getBacklog = backlog_id => async dispatch => {
+  try {
+    const res = await axios.get(`/api/backlog/${backlog_id}`);
+    dispatch({
+      type: GET_BACKLOG,
+      payload: res.data
+    });
+  } catch (err) {
+    dispatch({
+      type: GET_ERRORS,
+      payload: err.response.data
+    });
+  }
+};
+
+export const getProjectTask = (backlog_id, pt_id, history) => async dispatch => {
+  try {
+    const res = await axios.get(`/api/backlog/${backlog_id}/${pt_id}`);
+    dispatch({
+      type: GET_PROJECT_TASK,
+      payload: res.data
+    });
+  } catch (err) {
+    history.push("/dashboard");
+  }
+};
+
+export const updateProjectTask = (backlog_id, pt_id, project_task, history) => async dispatch => {
+  try {
+    const res = await axios.patch(`/api/backlog/${backlog_id}/${pt_id}`, project_task);
+    history.push(`/projectBoard/${backlog_id}`);
+    dispatch({
+      type: GET_ERRORS,
+      payload: {}
+    });
+  } catch (err) {
+    dispatch({
+      type: GET_ERRORS,
+      payload: err.response.data
+    });
+  }
+};
+
+export const deleteProjectTask = (backlog_id, pt_id) => async dispatch => {
+  if (window.confirm("Are you sure you want to delete this project task?")) {
+    await axios.delete(`/api/backlog/${backlog_id}/${pt_id}`);
+    dispatch({
+      type: DELETE_PROJECT_TASK,
+      payload: pt_id
+    });
+  }
+};

--- a/ppmtool-react-client/src/actions/projectActions.js
+++ b/ppmtool-react-client/src/actions/projectActions.js
@@ -1,6 +1,5 @@
 import axios from "axios";
 import { GET_ERRORS, GET_PROJECTS, GET_PROJECT, DELETE_PROJECT } from "./types";
-import { async } from "q";
 
 export const createProject = (project, history) => async dispatch => {
   try {

--- a/ppmtool-react-client/src/components/Project/ProjectItem.js
+++ b/ppmtool-react-client/src/components/Project/ProjectItem.js
@@ -24,11 +24,11 @@ class ProjectItem extends Component {
             </div>
             <div className="col-md-4 d-none d-lg-block">
               <ul className="list-group">
-                <a href="#">
+                <Link to={`/projectBoard/${project.projectIdentifier}`}>
                   <li className="list-group-item board">
                     <i className="fa fa-flag-checkered pr-1"> Project Board </i>
                   </li>
-                </a>
+                </Link>
                 <Link to={`/updateProject/${project.projectIdentifier}`}>
                   <li className="list-group-item update">
                     <i className="fa fa-edit pr-1"> Update Project Info</i>

--- a/ppmtool-react-client/src/components/Project/UpdateProject.js
+++ b/ppmtool-react-client/src/components/Project/UpdateProject.js
@@ -3,8 +3,6 @@ import { getProject, createProject } from "../../actions/projectActions";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import classnames from "classnames";
-import { timingSafeEqual } from "crypto";
-import { thisTypeAnnotation } from "@babel/types";
 
 class UpdateProject extends Component {
   // set state
@@ -95,7 +93,7 @@ class UpdateProject extends Component {
                     <div className="invalid-feedback">{errors.projectName}</div>
                   )}
                 </div>
-                <div class="form-group">
+                <div className="form-group">
                   <input
                     type="text"
                     className={classnames("form-control form-control-lg", {

--- a/ppmtool-react-client/src/components/ProjectBoard/Backlog.js
+++ b/ppmtool-react-client/src/components/ProjectBoard/Backlog.js
@@ -1,0 +1,17 @@
+import React, { Component } from "react";
+import ProjectTask from "./ProjectTasks/ProjectTask";
+
+class Backlog extends Component {
+  render() {
+    const { project_tasks_prop } = this.props;
+    return (
+      <div>
+        {project_tasks_prop.map(pt => (
+          <ProjectTask key={pt.id} project_task={pt} />
+        ))}
+      </div>
+    );
+  }
+}
+
+export default Backlog;

--- a/ppmtool-react-client/src/components/ProjectBoard/ProjectBoard.js
+++ b/ppmtool-react-client/src/components/ProjectBoard/ProjectBoard.js
@@ -1,0 +1,72 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+import { getBacklog } from "../../actions/backlogActions";
+import Backlog from "./Backlog";
+
+class ProjectBoard extends Component {
+  componentDidMount() {
+    const { id } = this.props.match.params;
+    this.props.getBacklog(id);
+  }
+
+  render() {
+    const { project_tasks } = this.props.backlog;
+    const { id } = this.props.match.params;
+
+    const todos = project_tasks.filter(pt => pt.status === "TO_DO");
+    const inProgress = project_tasks.filter(pt => pt.status === "IN_PROGRESS");
+    const done = project_tasks.filter(pt => pt.status === "DONE");
+
+    return (
+      <div className="container">
+        <Link to={`/addProjectTask/${id}`} className="btn btn-primary mb-3">
+          <i className="fa fa-plus-circle" /> Create Project Task
+        </Link>
+        <br />
+        <hr />
+        <div className="row">
+          <div className="col-md-4">
+            <div className="card text-center mb-3">
+              <div className="card-header bg-secondary text-white">
+                <h3>TO DO</h3>
+              </div>
+            </div>
+            <Backlog project_tasks_prop={todos} />
+          </div>
+          <div className="col-md-4">
+            <div className="card text-center mb-3">
+              <div className="card-header bg-primary text-white">
+                <h3>IN PROGRESS</h3>
+              </div>
+            </div>
+            <Backlog project_tasks_prop={inProgress} />
+          </div>
+          <div className="col-md-4">
+            <div className="card text-center mb-3">
+              <div className="card-header bg-success text-white">
+                <h3>DONE</h3>
+              </div>
+            </div>
+            <Backlog project_tasks_prop={done} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+ProjectBoard.propTypes = {
+  backlog: PropTypes.object.isRequired,
+  getBacklog: PropTypes.func.isRequired
+};
+
+const mapStateToProps = state => ({
+  backlog: state.backlog
+});
+
+export default connect(
+  mapStateToProps,
+  { getBacklog }
+)(ProjectBoard);

--- a/ppmtool-react-client/src/components/ProjectBoard/ProjectTasks/AddProjectTask.js
+++ b/ppmtool-react-client/src/components/ProjectBoard/ProjectTasks/AddProjectTask.js
@@ -1,0 +1,148 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+import { addProjectTask } from "../../../actions/backlogActions";
+import classnames from "classnames";
+
+class AddProjectTask extends Component {
+  constructor() {
+    super();
+    this.state = {
+      summary: "",
+      acceptanceCriteria: "",
+      status: "",
+      priority: "",
+      dueDate: "",
+      errors: {}
+    };
+    this.onChange = this.onChange.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.errors) {
+      this.setState({ errors: nextProps.errors });
+    }
+  }
+
+  onChange(e) {
+    this.setState({ [e.target.name]: e.target.value });
+  }
+
+  onSubmit(e) {
+    e.preventDefault();
+
+    const newProjectTask = {
+      summary: this.state.summary,
+      acceptanceCriteria: this.state.acceptanceCriteria,
+      status: this.state.status,
+      priority: this.state.priority,
+      dueDate: this.state.dueDate
+    };
+
+    const { id } = this.props.match.params;
+    this.props.addProjectTask(id, newProjectTask, this.props.history);
+  }
+
+  render() {
+    const { errors } = this.state;
+    const { id } = this.props.match.params;
+
+    return (
+      <div className="add-project-task">
+        <div className="container">
+          <div className="row">
+            <div className="col-md-8 m-auto">
+              <Link to={`/projectBoard/${id}`} className="btn btn-light">
+                Back to Project Board
+              </Link>
+              <h4 className="display-4 text-center">Add Project Task</h4>
+              <p className="lead text-center">Project ID: {id}</p>
+              <form onSubmit={this.onSubmit}>
+                <div className="form-group">
+                  <input
+                    type="text"
+                    className={classnames("form-control form-control-lg", {
+                      "is-invalid": errors.summary
+                    })}
+                    name="summary"
+                    placeholder="Project Task summary"
+                    value={this.state.summary}
+                    onChange={this.onChange}
+                  />
+                  {errors.summary && (
+                    <div className="invalid-feedback">{errors.summary}</div>
+                  )}
+                </div>
+                <div className="form-group">
+                  <textarea
+                    className="form-control form-control-lg"
+                    placeholder="Acceptance Criteria"
+                    name="acceptanceCriteria"
+                    value={this.state.acceptanceCriteria}
+                    onChange={this.onChange}
+                  />
+                </div>
+                <h6>Due Date</h6>
+                <div className="form-group">
+                  <input
+                    type="date"
+                    className="form-control form-control-lg"
+                    name="dueDate"
+                    value={this.state.dueDate}
+                    onChange={this.onChange}
+                  />
+                </div>
+                <div className="form-group">
+                  <select
+                    className="form-control form-control-lg"
+                    name="priority"
+                    value={this.state.priority}
+                    onChange={this.onChange}
+                  >
+                    <option value={0}>Select Priority</option>
+                    <option value={1}>High</option>
+                    <option value={2}>Medium</option>
+                    <option value={3}>Low</option>
+                  </select>
+                </div>
+                <div className="form-group">
+                  <select
+                    className="form-control form-control-lg"
+                    name="status"
+                    value={this.state.status}
+                    onChange={this.onChange}
+                  >
+                    <option value="">Select Status</option>
+                    <option value="TO_DO">TO DO</option>
+                    <option value="IN_PROGRESS">IN PROGRESS</option>
+                    <option value="DONE">DONE</option>
+                  </select>
+                </div>
+                <input
+                  type="submit"
+                  className="btn btn-primary btn-block mt-4"
+                />
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+AddProjectTask.propTypes = {
+  addProjectTask: PropTypes.func.isRequired,
+  errors: PropTypes.object.isRequired
+};
+
+const mapStateToProps = state => ({
+  errors: state.errors
+});
+
+export default connect(
+  mapStateToProps,
+  { addProjectTask }
+)(AddProjectTask);

--- a/ppmtool-react-client/src/components/ProjectBoard/ProjectTasks/ProjectTask.js
+++ b/ppmtool-react-client/src/components/ProjectBoard/ProjectTasks/ProjectTask.js
@@ -1,0 +1,68 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+import { deleteProjectTask } from "../../../actions/backlogActions";
+
+class ProjectTask extends Component {
+  onDeleteClick = (backlog_id, pt_id) => {
+    this.props.deleteProjectTask(backlog_id, pt_id);
+  };
+
+  render() {
+    const { project_task } = this.props;
+
+    let priorityString;
+    let priorityClass;
+    if (project_task.priority === 1) {
+      priorityString = "HIGH";
+      priorityClass = "bg-danger text-white";
+    } else if (project_task.priority === 2) {
+      priorityString = "MEDIUM";
+      priorityClass = "bg-warning text-white";
+    } else if (project_task.priority === 3) {
+      priorityString = "LOW";
+      priorityClass = "bg-info text-white";
+    } else {
+      priorityString = "UNKNOWN";
+      priorityClass = "";
+    }
+
+    return (
+      <div className="card mb-1 bg-light">
+        <div className={`card-header text-primary ${priorityClass}`}>
+          ID: {project_task.projectSequence} -- Priority: {priorityString}
+        </div>
+        <div className="card-body bg-light">
+          <h5 className="card-title">{project_task.summary}</h5>
+          <p className="card-text text-truncate ">{project_task.acceptanceCriteria}</p>
+          <Link
+            to={`/updateProjectTask/${project_task.projectIdentifier}/${project_task.projectSequence}`}
+            className="btn btn-primary"
+          >
+            Update
+          </Link>
+          <button
+            className="btn btn-danger ml-4"
+            onClick={this.onDeleteClick.bind(
+              this,
+              project_task.projectIdentifier,
+              project_task.projectSequence
+            )}
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+
+ProjectTask.propTypes = {
+  deleteProjectTask: PropTypes.func.isRequired
+};
+
+export default connect(
+  null,
+  { deleteProjectTask }
+)(ProjectTask);

--- a/ppmtool-react-client/src/components/ProjectBoard/ProjectTasks/UpdateProjectTask.js
+++ b/ppmtool-react-client/src/components/ProjectBoard/ProjectTasks/UpdateProjectTask.js
@@ -1,0 +1,186 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+import { getProjectTask, updateProjectTask } from "../../../actions/backlogActions";
+import classnames from "classnames";
+
+class UpdateProjectTask extends Component {
+  constructor() {
+    super();
+    this.state = {
+      id: "",
+      projectSequence: "",
+      summary: "",
+      acceptanceCriteria: "",
+      status: "",
+      priority: "",
+      dueDate: "",
+      projectIdentifier: "",
+      errors: {}
+    };
+    this.onChange = this.onChange.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.errors) {
+      this.setState({ errors: nextProps.errors });
+    }
+
+    const {
+      id,
+      projectSequence,
+      summary,
+      acceptanceCriteria,
+      status,
+      priority,
+      dueDate,
+      projectIdentifier
+    } = nextProps.project_task;
+
+    this.setState({
+      id,
+      projectSequence,
+      summary,
+      acceptanceCriteria,
+      status,
+      priority,
+      dueDate,
+      projectIdentifier
+    });
+  }
+
+  componentDidMount() {
+    const { backlog_id, pt_id } = this.props.match.params;
+    this.props.getProjectTask(backlog_id, pt_id, this.props.history);
+  }
+
+  onChange(e) {
+    this.setState({ [e.target.name]: e.target.value });
+  }
+
+  onSubmit(e) {
+    e.preventDefault();
+
+    const updatedTask = {
+      id: this.state.id,
+      projectSequence: this.state.projectSequence,
+      summary: this.state.summary,
+      acceptanceCriteria: this.state.acceptanceCriteria,
+      status: this.state.status,
+      priority: this.state.priority,
+      dueDate: this.state.dueDate,
+      projectIdentifier: this.state.projectIdentifier
+    };
+
+    const { backlog_id, pt_id } = this.props.match.params;
+    this.props.updateProjectTask(backlog_id, pt_id, updatedTask, this.props.history);
+  }
+
+  render() {
+    const { errors } = this.state;
+    const { backlog_id } = this.props.match.params;
+
+    return (
+      <div className="add-project-task">
+        <div className="container">
+          <div className="row">
+            <div className="col-md-8 m-auto">
+              <Link to={`/projectBoard/${backlog_id}`} className="btn btn-light">
+                Back to Project Board
+              </Link>
+              <h4 className="display-4 text-center">Update Project Task</h4>
+              <p className="lead text-center">
+                Project ID: {backlog_id}
+              </p>
+              <form onSubmit={this.onSubmit}>
+                <div className="form-group">
+                  <input
+                    type="text"
+                    className={classnames("form-control form-control-lg", {
+                      "is-invalid": errors.summary
+                    })}
+                    name="summary"
+                    placeholder="Project Task summary"
+                    value={this.state.summary}
+                    onChange={this.onChange}
+                  />
+                  {errors.summary && (
+                    <div className="invalid-feedback">{errors.summary}</div>
+                  )}
+                </div>
+                <div className="form-group">
+                  <textarea
+                    className="form-control form-control-lg"
+                    placeholder="Acceptance Criteria"
+                    name="acceptanceCriteria"
+                    value={this.state.acceptanceCriteria}
+                    onChange={this.onChange}
+                  />
+                </div>
+                <h6>Due Date</h6>
+                <div className="form-group">
+                  <input
+                    type="date"
+                    className="form-control form-control-lg"
+                    name="dueDate"
+                    value={this.state.dueDate}
+                    onChange={this.onChange}
+                  />
+                </div>
+                <div className="form-group">
+                  <select
+                    className="form-control form-control-lg"
+                    name="priority"
+                    value={this.state.priority}
+                    onChange={this.onChange}
+                  >
+                    <option value={0}>Select Priority</option>
+                    <option value={1}>High</option>
+                    <option value={2}>Medium</option>
+                    <option value={3}>Low</option>
+                  </select>
+                </div>
+                <div className="form-group">
+                  <select
+                    className="form-control form-control-lg"
+                    name="status"
+                    value={this.state.status}
+                    onChange={this.onChange}
+                  >
+                    <option value="">Select Status</option>
+                    <option value="TO_DO">TO DO</option>
+                    <option value="IN_PROGRESS">IN PROGRESS</option>
+                    <option value="DONE">DONE</option>
+                  </select>
+                </div>
+                <input
+                  type="submit"
+                  className="btn btn-primary btn-block mt-4"
+                />
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+UpdateProjectTask.propTypes = {
+  getProjectTask: PropTypes.func.isRequired,
+  updateProjectTask: PropTypes.func.isRequired,
+  project_task: PropTypes.object.isRequired,
+  errors: PropTypes.object.isRequired
+};
+
+const mapStateToProps = state => ({
+  project_task: state.backlog.project_task,
+  errors: state.errors
+});
+
+export default connect(
+  mapStateToProps,
+  { getProjectTask, updateProjectTask }
+)(UpdateProjectTask);

--- a/ppmtool-react-client/src/reducers/backlogReducer.js
+++ b/ppmtool-react-client/src/reducers/backlogReducer.js
@@ -24,9 +24,10 @@ export default function(state = initialState, action) {
       };
     case DELETE_PROJECT_TASK:
       return {
-        ...state
-
-        // TODO
+        ...state,
+        project_tasks: state.project_tasks.filter(
+          pt => pt.projectSequence !== action.payload
+        )
       };
 
     default:

--- a/ppmtool-react-client/src/store.js
+++ b/ppmtool-react-client/src/store.js
@@ -18,7 +18,7 @@ if (window.navigator.userAgent.includes("Chrome")) {
     )
   );
 } else {
-  compose(applyMiddleware(...middleware));
+  store = createStore(rootReducer, initialState, applyMiddleware(...middleware));
 }
 
 export default store;


### PR DESCRIPTION
- Create backlogActions.js with full CRUD action creators for project tasks
- Implement 5 empty components: ProjectBoard, Backlog, AddProjectTask, ProjectTask, UpdateProjectTask
- Fix backlogReducer DELETE_PROJECT_TASK case (was a TODO stub)
- Fix store.js: non-Chrome browsers were getting undefined store
- Fix UpdateProject.js: remove invalid crypto and @babel/types imports, fix class -> className
- Fix projectActions.js: remove unused 'async' import from 'q'
- Add routes in App.js for projectBoard, addProjectTask, updateProjectTask
- Fix ProjectItem.js: replace broken href="#" with proper Link to project board
