### PR TITLE
Upgrade Java, Spring Boot, JWT, MySQL connector, and React dependencies

### DIFF
--- a/PPMTool/pom.xml
+++ b/PPMTool/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.3.RELEASE</version>
+    <version>3.2.3</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>com.vasvass</groupId>
@@ -15,7 +15,7 @@
   <description>Personal Project Management Tool</description>
 
   <properties>
-    <java.version>1.8</java.version>
+    <java.version>21</java.version>
   </properties>
 
   <dependencies>
@@ -39,8 +39,8 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -54,8 +54,20 @@
     </dependency>
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
-      <artifactId>jjwt</artifactId>
-      <version>0.9.1</version>
+      <artifactId>jjwt-api</artifactId>
+      <version>0.12.5</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>0.12.5</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>0.12.5</version>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 

--- a/PPMTool/src/main/java/com/vasvass/ppmtool/domain/Backlog.java
+++ b/PPMTool/src/main/java/com/vasvass/ppmtool/domain/Backlog.java
@@ -2,7 +2,7 @@ package com.vasvass.ppmtool.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.*;
 
 /**

--- a/PPMTool/src/main/java/com/vasvass/ppmtool/domain/Project.java
+++ b/PPMTool/src/main/java/com/vasvass/ppmtool/domain/Project.java
@@ -8,8 +8,8 @@ package com.vasvass.ppmtool.domain;
 
 import com.fasterxml.jackson.annotation.*;
 
-import javax.persistence.*;
-import javax.validation.constraints.*;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
 import java.util.Date;
 
 

--- a/PPMTool/src/main/java/com/vasvass/ppmtool/domain/ProjectTask.java
+++ b/PPMTool/src/main/java/com/vasvass/ppmtool/domain/ProjectTask.java
@@ -2,8 +2,8 @@ package com.vasvass.ppmtool.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import javax.persistence.*;
-import javax.validation.constraints.NotBlank;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
 import java.util.Date;
 
 /**

--- a/PPMTool/src/main/java/com/vasvass/ppmtool/domain/User.java
+++ b/PPMTool/src/main/java/com/vasvass/ppmtool/domain/User.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import javax.persistence.*;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotBlank;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;

--- a/PPMTool/src/main/java/com/vasvass/ppmtool/payload/LoginRequest.java
+++ b/PPMTool/src/main/java/com/vasvass/ppmtool/payload/LoginRequest.java
@@ -1,6 +1,6 @@
 package com.vasvass.ppmtool.payload;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 public class LoginRequest {
 

--- a/PPMTool/src/main/java/com/vasvass/ppmtool/security/JwtAuthEntryPoint.java
+++ b/PPMTool/src/main/java/com/vasvass/ppmtool/security/JwtAuthEntryPoint.java
@@ -6,8 +6,8 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;

--- a/PPMTool/src/main/java/com/vasvass/ppmtool/security/JwtAuthenticationFilter.java
+++ b/PPMTool/src/main/java/com/vasvass/ppmtool/security/JwtAuthenticationFilter.java
@@ -9,10 +9,10 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collections;
 

--- a/PPMTool/src/main/java/com/vasvass/ppmtool/security/JwtTokenProvider.java
+++ b/PPMTool/src/main/java/com/vasvass/ppmtool/security/JwtTokenProvider.java
@@ -2,12 +2,16 @@ package com.vasvass.ppmtool.security;
 
 import com.vasvass.ppmtool.domain.User;
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -23,6 +27,10 @@ public class JwtTokenProvider {
     @Value("${app.jwtExpirationInMs}")
     private int jwtExpirationInMs;
 
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+    }
+
     public String generateToken(Authentication authentication) {
         User user = (User) authentication.getPrincipal();
         Date now = new Date(System.currentTimeMillis());
@@ -36,17 +44,17 @@ public class JwtTokenProvider {
         claims.put("fullName", user.getFullName());
 
         return Jwts.builder()
-                .setSubject(userId)
-                .setClaims(claims)
-                .setIssuedAt(now)
-                .setExpiration(expiryDate)
-                .signWith(SignatureAlgorithm.HS512, jwtSecret)
+                .subject(userId)
+                .claims(claims)
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(getSigningKey())
                 .compact();
     }
 
     public boolean validateToken(String token) {
         try {
-            Jwts.parser().setSigningKey(jwtSecret).parseClaimsJws(token);
+            Jwts.parser().verifyWith(getSigningKey()).build().parseSignedClaims(token);
             return true;
         } catch (SignatureException ex) {
             logger.error("Invalid JWT Signature: {}", ex.getMessage());
@@ -63,7 +71,8 @@ public class JwtTokenProvider {
     }
 
     public Long getUserIdFromJWT(String token) {
-        Claims claims = Jwts.parser().setSigningKey(jwtSecret).parseClaimsJws(token).getBody();
+        Claims claims = Jwts.parser().verifyWith(getSigningKey()).build()
+                .parseSignedClaims(token).getPayload();
         String id = (String) claims.get("id");
         return Long.parseLong(id);
     }

--- a/PPMTool/src/main/java/com/vasvass/ppmtool/security/SecurityConfig.java
+++ b/PPMTool/src/main/java/com/vasvass/ppmtool/security/SecurityConfig.java
@@ -5,14 +5,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.BeanIds;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import static com.vasvass.ppmtool.security.SecurityConstants.H2_URL;
@@ -20,8 +22,8 @@ import static com.vasvass.ppmtool.security.SecurityConstants.SIGN_UP_URLS;
 
 @Configuration
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(securedEnabled = true, jsr250Enabled = true, prePostEnabled = true)
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+@EnableMethodSecurity(securedEnabled = true, jsr250Enabled = true, prePostEnabled = true)
+public class SecurityConfig {
 
     @Autowired
     private JwtAuthEntryPoint unauthorizedHandler;
@@ -35,37 +37,37 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
     @Bean
-    BCryptPasswordEncoder bCryptPasswordEncoder() {
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
-    @Override
-    protected void configure(AuthenticationManagerBuilder authenticationManagerBuilder) throws Exception {
-        authenticationManagerBuilder.userDetailsService(customUserDetailsService)
-                .passwordEncoder(bCryptPasswordEncoder());
+    @Bean
+    public DaoAuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(customUserDetailsService);
+        authProvider.setPasswordEncoder(bCryptPasswordEncoder());
+        return authProvider;
     }
 
-    @Override
-    @Bean(BeanIds.AUTHENTICATION_MANAGER)
-    protected AuthenticationManager authenticationManager() throws Exception {
-        return super.authenticationManager();
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
+        return authConfig.getAuthenticationManager();
     }
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.cors().and().csrf().disable()
-                .exceptionHandling().authenticationEntryPoint(unauthorizedHandler)
-                .and()
-                .sessionManagement()
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
-                .headers().frameOptions().sameOrigin()
-                .and()
-                .authorizeRequests()
-                .antMatchers(SIGN_UP_URLS).permitAll()
-                .antMatchers(H2_URL).permitAll()
-                .anyRequest().authenticated();
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.cors(cors -> {})
+                .csrf(AbstractHttpConfigurer::disable)
+                .exceptionHandling(ex -> ex.authenticationEntryPoint(unauthorizedHandler))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(SIGN_UP_URLS).permitAll()
+                        .requestMatchers(H2_URL).permitAll()
+                        .anyRequest().authenticated());
 
+        http.authenticationProvider(authenticationProvider());
         http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+        return http.build();
     }
 }

--- a/PPMTool/src/main/java/com/vasvass/ppmtool/services/CustomUserDetailsService.java
+++ b/PPMTool/src/main/java/com/vasvass/ppmtool/services/CustomUserDetailsService.java
@@ -25,8 +25,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     }
 
     public User loadUserById(Long id) {
-        User user = userRepository.getById(id);
-        if (user == null) throw new UsernameNotFoundException("User not found");
-        return user;
+        return userRepository.findById(id)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
     }
 }

--- a/PPMTool/src/main/java/com/vasvass/ppmtool/web/UserController.java
+++ b/PPMTool/src/main/java/com/vasvass/ppmtool/web/UserController.java
@@ -18,7 +18,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/users")

--- a/PPMTool/src/main/resources/application.properties
+++ b/PPMTool/src/main/resources/application.properties
@@ -9,7 +9,7 @@ spring.datasource.url=jdbc:mysql://localhost:3306/ppmtooldb?useUnicode=true&useJ
 spring.datasource.username=ppmtoolusr
 spring.datasource.password=ppmtoolpwd
 
-spring.jpa.database-platform=org.hibernate.dialect.MySQL5Dialect
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.hibernate.ddl-auto=update

--- a/ppmtool-react-client/package.json
+++ b/ppmtool-react-client/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
-    "react-scripts": "3.0.1"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Backend:
- Java 1.8 → 21
- Spring Boot 2.1.3.RELEASE → 3.2.3
- Migrate all javax.* imports to jakarta.* (JPA, validation, servlet)
- Rewrite SecurityConfig using Spring Security 6 (SecurityFilterChain, @EnableMethodSecurity)
- Update jjwt 0.9.1 → 0.12.5 (new split artifacts, updated builder/parser API)
- Replace deprecated mysql:mysql-connector-java with com.mysql:mysql-connector-j
- Update Hibernate dialect MySQL5Dialect → MySQLDialect
- Replace deprecated UserRepository.getById() with findById()

Frontend:
- React 16.8.6 → 18.3.1
- react-scripts 3.0.1 → 5.0.1
