### PR TITLE
Migrate validation imports from javax to jakarta

### DIFF
--- a/PPMTool/pom.xml
+++ b/PPMTool/pom.xml
@@ -53,6 +53,10 @@
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt-api</artifactId>
       <version>0.12.5</version>

--- a/PPMTool/src/main/java/com/vasvass/ppmtool/web/BacklogController.java
+++ b/PPMTool/src/main/java/com/vasvass/ppmtool/web/BacklogController.java
@@ -7,7 +7,7 @@ import org.springframework.http.*;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.security.Principal;
 
 

--- a/PPMTool/src/main/java/com/vasvass/ppmtool/web/ProjectController.java
+++ b/PPMTool/src/main/java/com/vasvass/ppmtool/web/ProjectController.java
@@ -7,7 +7,7 @@ import org.springframework.http.*;
 import org.springframework.validation.*;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.security.Principal;
 
 /**


### PR DESCRIPTION
## Summary
Updated validation imports to use the Jakarta EE namespace instead of the legacy javax namespace, aligning with Spring Boot 3.x standards.

## Key Changes
- Added `spring-boot-starter-validation` dependency to pom.xml
- Migrated `@Valid` annotation imports from `javax.validation` to `jakarta.validation` in:
  - `BacklogController.java`
  - `ProjectController.java`

## Details
This change reflects the transition from Java EE (javax) to Jakarta EE (jakarta) namespaces. The `spring-boot-starter-validation` dependency provides the necessary validation framework with the updated Jakarta imports, ensuring compatibility with modern Spring Boot versions and removing reliance on deprecated javax packages.
