### PR TITLE
Add explicit table name mapping to User entity

### DIFF
--- a/PPMTool/src/main/java/com/vasvass/ppmtool/domain/User.java
+++ b/PPMTool/src/main/java/com/vasvass/ppmtool/domain/User.java
@@ -13,6 +13,7 @@ import java.util.Date;
 import java.util.List;
 
 @Entity
+@Table(name = "users")
 public class User implements UserDetails {
 
     @Id


### PR DESCRIPTION
## Summary
Added explicit JPA table name annotation to the User entity to ensure the database table is explicitly mapped to "users".

## Key Changes
- Added `@Table(name = "users")` annotation to the User class
  - Provides explicit table name mapping instead of relying on default naming conventions
  - Ensures consistency between the entity class name and the actual database table name

## Implementation Details
This change makes the table mapping explicit and convention-independent, which can help prevent naming conflicts and makes the database schema more maintainable. The annotation is placed directly after the `@Entity` annotation, following JPA best practices.