### PR TITLE
Fix password validation always failing on registration

### DIFF
--- a/PPMTool/src/main/java/com/vasvass/ppmtool/domain/User.java
+++ b/PPMTool/src/main/java/com/vasvass/ppmtool/domain/User.java
@@ -1,6 +1,7 @@
 package com.vasvass.ppmtool.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -29,7 +30,7 @@ public class User implements UserDetails {
     private String fullName;
 
     @NotBlank(message = "Password field is required")
-    @JsonIgnore
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String password;
 
     @Transient


### PR DESCRIPTION
## Summary

- The `password` field in `User.java` was annotated with `@JsonIgnore`, which blocked Jackson from deserializing the password from incoming registration requests
- This caused `getPassword()` to always return `null`, triggering the "Password must be at least 6 characters" error even when the user entered a valid 8+ character password
- Fixed by replacing `@JsonIgnore` with `@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)`, which allows deserialization from JSON while still preventing the password from being included in outgoing responses

## Test plan

- [x] Register a new user with a password of 6 or more characters — should succeed without error
- [x] Register with a password shorter than 6 characters — should still show the validation error
- [x] Confirm the password is not exposed in any API response (e.g., GET user endpoint)
- [x] Verify existing unit tests in `UserValidatorTest` still pass